### PR TITLE
Support for property chain in @ binding syntax

### DIFF
--- a/src/Avalonia.Markup.Declarative/PropertyPathHelper.cs
+++ b/src/Avalonia.Markup.Declarative/PropertyPathHelper.cs
@@ -21,8 +21,8 @@ public static class PropertyPathHelper
             //found special characters after property name, ie: @vm.Property ?? 0
             if (propFound && Array.IndexOf(StopChars, curChar) > -1)
                 return path.Substring(startIndex, i - startIndex);
-            
-            if (curChar == '.')
+
+            if (!propFound && curChar == '.')
             {
                 //found start of property name
                 startIndex = ++i;

--- a/src/Samples/AvaloniaMarkupSample/MvvmSample/MvvmSampleView.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvvmSample/MvvmSampleView.cs
@@ -20,7 +20,7 @@ public class MvvmSampleView() : ViewBase<MvvmSampleViewModel>(new MvvmSampleView
         new StackPanel()
             .Children(
                 new TextBlock()
-                    .Text(@vm.MyProperty),
+                    .Text(@vm.MyObject.MyProperty),
 
                 new Button()
                     .Content("Execute Command")

--- a/src/Samples/AvaloniaMarkupSample/MvvmSample/MvvmSampleViewModel.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvvmSample/MvvmSampleViewModel.cs
@@ -3,18 +3,21 @@ using System.Runtime.CompilerServices;
 
 namespace AvaloniaMarkupSample.MvvmSample;
 
+public record struct MyObject(
+    string MyProperty);
+
 public class MvvmSampleViewModel : INotifyPropertyChanged
 {
-    private string? _myProperty;
+    private MyObject _myObject = new("Click the button below.");
 
-    public string? MyProperty
+    public MyObject MyObject
     {
-        get => _myProperty;
+        get => _myObject;
         set
         {
-            if (_myProperty != value)
+            if (_myObject != value)
             {
-                _myProperty = value;
+                _myObject = value;
                 OnPropertyChanged();
             }
         }
@@ -22,7 +25,7 @@ public class MvvmSampleViewModel : INotifyPropertyChanged
 
     public void MyCommand(object? commandParameter)
     {
-        MyProperty = $"You called command with parameter: {commandParameter}";
+        MyObject = new($"You called command with parameter: {commandParameter}");
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
The way it was before didn't work with property chains like `@vm.Foo.Bar.Baz`