### PR TITLE
fix: binding with null Source

### DIFF
--- a/src/Avalonia.Markup.Declarative/ControlPropertyExtensions.cs
+++ b/src/Avalonia.Markup.Declarative/ControlPropertyExtensions.cs
@@ -159,9 +159,14 @@ public static class ControlPropertyExtensions
 			{
 				Path = PropertyPathHelper.GetNameFromPropertyPath(sourcePropertyPathString),
 				Mode = bindingMode ?? BindingMode.Default,
-				Converter = converter,
-				Source = bindingSource
+				Converter = converter
 			};
+
+			// This is needed as setting a null Source breaks the Binding
+			if (bindingSource != null)
+			{
+				binding.Source = bindingSource;
+			}
 
 			//for components the default binding context is the component itself instead of the control's data context
 			var view = ViewBuildContext.CurrentView;


### PR DESCRIPTION
Without this fix, bindings that use the _setEx method with a null bindingSource do not work. This is a critical fix as most bindings do not work.