### PR TITLE
fix: tfm version walking

### DIFF
--- a/src/AvaloniaExtensionGenerator/CsProjectTypesExtractor.cs
+++ b/src/AvaloniaExtensionGenerator/CsProjectTypesExtractor.cs
@@ -263,11 +263,23 @@ namespace AvaloniaExtensionGenerator
             if (Directory.Exists(frameworkPath))
                 return true;
 
-            frameworkPath = Path.Combine(libPath, "netstandard2.0");
+            var framework = NuGetFramework.ParseFolder(targetFramework);
+
+            if (framework.Framework == ".NETCoreApp")
+            {
+                for (int i = framework.Version.Major; i >= 6; i--)
+                {
+                    frameworkPath = Path.Combine(libPath, $"net{i}.0");
+                    if (Directory.Exists(frameworkPath))
+                        return true;
+                }
+            }
+
+            frameworkPath = Path.Combine(libPath, "netstandard2.1");
             if (Directory.Exists(frameworkPath))
                 return true;
 
-            frameworkPath = Path.Combine(libPath, "netstandard2.1");
+            frameworkPath = Path.Combine(libPath, "netstandard2.0");
             if (Directory.Exists(frameworkPath))
                 return true;
 

--- a/src/AvaloniaExtensionGenerator/CsProjectTypesExtractor.cs
+++ b/src/AvaloniaExtensionGenerator/CsProjectTypesExtractor.cs
@@ -267,7 +267,7 @@ namespace AvaloniaExtensionGenerator
 
             if (framework.Framework == ".NETCoreApp")
             {
-                for (int i = framework.Version.Major; i >= 6; i--)
+                for (int i = framework.Version.Major - 1; i >= 6; i--)
                 {
                     frameworkPath = Path.Combine(libPath, $"net{i}.0");
                     if (Directory.Exists(frameworkPath))


### PR DESCRIPTION
Fixes #61

- Enabled TryToFindFrameworkPath to look for files in older support Target Framework Versions
- Changed order of netstandard2.0 and netstandard2.1 (Preference should be for more modern TFMs)