### PR TITLE
Fix root‑name slicing in CreateMvuBinding so @vm.Prop yields vm

### DIFF
--- a/src/Avalonia.Markup.Declarative/ComponentBase.cs
+++ b/src/Avalonia.Markup.Declarative/ComponentBase.cs
@@ -162,7 +162,7 @@ public abstract class ComponentBase : ViewBase, IMvuComponent
         if (splitterIndex > -1)
         {
             var startIndex = valueExpressionString.StartsWith("@") ? 1 : 0;
-            stateName = valueExpressionString.Substring(0, splitterIndex - startIndex);
+            stateName = valueExpressionString.Substring(startIndex, splitterIndex - startIndex);
 
             useStateValueAsSource = true;
         }


### PR DESCRIPTION
## Description

 I believe in CreateMvuBinding you still want to support the magic '@' syntax which seems to be broken:

CreateMvuBinding was doing:

```C#
var splitterIndex = valueExpressionString!.IndexOf('.');
var startIndex     = valueExpressionString.StartsWith("@") ? 1 : 0;
stateName          = valueExpressionString.Substring(0, splitterIndex - startIndex);
```

For "@vm.Foo" that yields Substring(0, 3-1) ⇒ "@v" instead of "vm", so the binding lookup always failed.

I tested this with the sample

```C#
SampleMvuView
// ...
    new TextBlock()
        .Text(Bind(@State.StateProperty)),
// ..

``` 

and this breaks. But it works fine with this patch

**Disclaimer**

I'm just starting out with this and am learning by reading the code. 
So bare with me ...