### PR TITLE
Support events with generic EventArg types

### DIFF
--- a/src/AvaloniaExtensionGenerator/ExtensionInfos/EventExtensionInfo.cs
+++ b/src/AvaloniaExtensionGenerator/ExtensionInfos/EventExtensionInfo.cs
@@ -1,6 +1,6 @@
 using AvaloniaExtensionGenerator.Generators;
 using System.Reflection;
-using System.Reflection.Metadata;
+using System.Text.RegularExpressions;
 
 namespace AvaloniaExtensionGenerator.ExtensionInfos;
 
@@ -24,7 +24,7 @@ public class EventExtensionInfo : IMemberExtensionInfo
 
     public bool HasStandardSignature =>
         EventParameterTypes.Count == 2 && EventParameterTypes[0] == "System.Object" &&
-        EventParameterTypes[1].EndsWith("EventArgs");
+        Regex.IsMatch(EventParameterTypes[1], @"\b\w*EventArgs(\<.*\>)?$");
 
     public bool HasSingleParameter => EventParameterTypes.Count == 1;
     public bool HasMultipleParameters => EventParameterTypes.Count > 1;
@@ -50,12 +50,12 @@ public class EventExtensionInfo : IMemberExtensionInfo
         if (methodInfo != null)
         {
             var parameters = methodInfo.GetParameters();
-            foreach (var parameter in parameters) 
+            foreach (var parameter in parameters)
                 EventParameterTypes.Add(parameter.ParameterType.GetTypeDeclarationSourceCode());
 
             if (HasRoutedEventArgs(parameters))
             {
-                var routedEventFieldInfo = ControlType.GetField(EventName + "Event", BindingFlags.Static | BindingFlags.Public); 
+                var routedEventFieldInfo = ControlType.GetField(EventName + "Event", BindingFlags.Static | BindingFlags.Public);
                 IsRoutedEvent = routedEventFieldInfo != null; //if routed event field located in base class, ignore it and cout it classic event
             }
 


### PR DESCRIPTION
The generation currently produces wrong code for event handlers generic EventArgs.

For example: `Ursa.Controls.ValueChangedEventArgs<System.Int32>`

For Ursas pagination event it currently produces: 
(keeps the extra first parameter in the callback action)

```C#
/*ActionToEventGenerator*/
public static T OnCurrentPageChanged<T>(this T control, Action<object, Ursa.Controls.ValueChangedEventArgs<System.Int32>> action, Avalonia.Interactivity.RoutingStrategies? routes = null) where T : Ursa.Controls.Pagination
{
  control.AddHandler(Ursa.Controls.Pagination.CurrentPageChangedEvent, (_, args) => action(args), routes ?? Ursa.Controls.Pagination.CurrentPageChangedEvent.RoutingStrategies);
  return control;
}
```

The proposed changing the `EndsWith` check to a Regex.