### PR TITLE
Remove OnCreatedCore in ViewBase; Invoke OnCreated inside Initialize

### DIFF
--- a/src/Avalonia.Markup.Declarative/ComponentBase.cs
+++ b/src/Avalonia.Markup.Declarative/ComponentBase.cs
@@ -25,7 +25,6 @@ public abstract class ComponentBase<TViewModel> : ComponentBase
         : base(true)
     {
         DataContext = viewModel;
-        OnCreatedCore();
         Initialize();
     }
 

--- a/src/Avalonia.Markup.Declarative/ViewBase.cs
+++ b/src/Avalonia.Markup.Declarative/ViewBase.cs
@@ -22,7 +22,6 @@ public abstract class ViewBase<TViewModel> : ViewBase
         : base(true)
     {
         DataContext = viewModel;
-        OnCreatedCore();
         Initialize();
     }
 
@@ -62,14 +61,9 @@ public abstract class ViewBase : Decorator, IReloadable, IDeclarativeViewBase
     {
         if (!deferredLoading)
         {
-            OnCreatedCore();
             Initialize();
         }
     }
-
-    protected virtual void OnAfterInitialized() { }
-
-    protected internal void OnCreatedCore() => OnCreated();
 
     /// <summary>
     /// Called from constructor, right before initialization and building UI
@@ -79,10 +73,13 @@ public abstract class ViewBase : Decorator, IReloadable, IDeclarativeViewBase
     {
     }
 
+    protected virtual void OnAfterInitialized() { }
+
     public void Initialize()
     {
         try
         {
+            OnCreated();
             NameScope.SetNameScope(this, Scope);
 
             using (var context = new ViewBuildContext(this))
@@ -170,7 +167,6 @@ public abstract class ViewBase : Decorator, IReloadable, IDeclarativeViewBase
             var oldDataContext = DataContext; 
             DataContext = null; // guarantee that OnDataContextChanged is called
 
-            OnCreatedCore();
             Initialize();
             DataContext = oldDataContext; // set DataContext back
 

--- a/src/Samples/ReactiveSample/Views/ReactiveViewBase.cs
+++ b/src/Samples/ReactiveSample/Views/ReactiveViewBase.cs
@@ -24,7 +24,6 @@ public abstract class ReactiveViewBase<TViewModel> : ViewBase, IViewFor<TViewMod
 
         if (DataContext != null)
         {
-            OnCreatedCore();
             Initialize();
         }
     }


### PR DESCRIPTION
I observed the **internal** method OnCreatedCore need to be called immediately before initialize.  Why not remove it and call OnCreated inside Initialize?

I found it error-prone and awkward to call the internal
OnCreatedCore(); 
in user's code.  