### PR TITLE
Same level controls binding

### DIFF
--- a/src/Avalonia.Markup.Declarative.SourceGenerator/MarkupTypeHelpers.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/MarkupTypeHelpers.cs
@@ -26,9 +26,7 @@ internal static class MarkupTypeHelpers
             .Where(d => d.IsKind(SyntaxKind.ClassDeclaration))
             .OfType<ClassDeclarationSyntax>();
 
-        return allClasses
-            .Where(type => IsGenerateExtensionsView(compilation, type))
-            .ToImmutableArray();
+        return [..allClasses.Where(type => IsGenerateExtensionsView(compilation, type))];
     }
 
     private static bool IsGenerateExtensionsView(Compilation compilation, ClassDeclarationSyntax component)

--- a/src/Avalonia.Markup.Declarative.Tests/ControlsTests/BindPropertySameLevelSyncTest.cs
+++ b/src/Avalonia.Markup.Declarative.Tests/ControlsTests/BindPropertySameLevelSyncTest.cs
@@ -1,0 +1,85 @@
+using Avalonia.Controls;
+using System.Globalization;
+
+namespace Avalonia.Markup.Declarative.Tests.ControlsTests;
+
+public class BindPropertySameLevelSyncTest : AvaloniaTestBase
+{
+    [Fact]
+    public void ExternalPropertySetTestView_InnerValueChangePoppedToParentComponent()
+    {
+        var view = new SliderTestView();
+
+        var window = new Window { Content = view };
+        window.Show();
+
+        Assert.Equal(1, view.Value);
+
+        var expectedValue = 50;
+        view._sliderEx._slider.Value = expectedValue;
+
+        Assert.Equal(expectedValue, view._sliderEx.Value);
+        Assert.Equal(expectedValue, view._sliderEx._slider.Value);
+        Assert.Equal(expectedValue, view._sliderEx._numericUpDown.Value);
+        Assert.Equal(expectedValue, view.Value);
+    }
+
+    public class SliderWrapperEx : ComponentBase
+    {
+        protected override object Build() =>
+        new Grid()
+            .Rows("Auto,Auto")
+            .Cols("Auto,*, 20")
+            .Margin(0, 4)
+            .Children(
+                new TextBlock()
+                    .Text(() => Label),
+
+                new NumericUpDown()
+                    .Col(1)
+                    .Ref(out _numericUpDown)
+                    .Width(80)
+                    .Minimum(() => (decimal)Minimum)
+                    .Maximum(() => (decimal)Maximum)
+                    .NumberFormat(new NumberFormatInfo() { NumberDecimalDigits = 0 })
+                    .Increment(1)
+                    .Value(() => (decimal?)Value, v => Value = (double)v!),
+
+                new TextBlock()
+                    .Text(() => Units)
+                    .Margin(4)
+                    .Col(2),
+
+                new Slider()
+                    .Ref(out _slider)
+                    .Row(1)
+                    .ColSpan(3)
+                    .TickFrequency(1)
+                    .IsSnapToTickEnabled(true)
+                    .Maximum(() => Maximum)
+                    .Minimum(() => Minimum)
+                    .SmallChange(1)
+                    .LargeChange(10)
+                    .Value(() => Value, v => Value = v)
+            );
+
+        public double Value { get; set; } = 0;
+        public double Minimum { get; set; } = 0;
+        public double Maximum { get; set; } = 100;
+        public string Label { get; set; } = "";
+        public string Units { get; set; } = "";
+
+        public Slider _slider = null!;
+        public NumericUpDown _numericUpDown = null!;
+    }
+    public class SliderTestView : ComponentBase
+    {
+        protected override object Build() =>
+            new SliderWrapperEx()
+                .Ref(out _sliderEx)
+                .Value(() => Value, v => Value = v);
+
+        public SliderWrapperEx _sliderEx = null!;
+        public double Value { get; set; } = 1d;
+    }
+}

--- a/src/Avalonia.Markup.Declarative.Tests/ControlsTests/BindPropertySameLevelSyncTest.cs
+++ b/src/Avalonia.Markup.Declarative.Tests/ControlsTests/BindPropertySameLevelSyncTest.cs
@@ -43,7 +43,7 @@ public class BindPropertySameLevelSyncTest : AvaloniaTestBase
                     .Maximum(() => (decimal)Maximum)
                     .NumberFormat(new NumberFormatInfo() { NumberDecimalDigits = 0 })
                     .Increment(1)
-                    .Value(() => (decimal?)Value, v => Value = (double)v!),
+                    .Value(() => (decimal?)Value, v => { if (v.HasValue) Value = (double)v.Value; }),
 
                 new TextBlock()
                     .Text(() => Units)

--- a/src/Avalonia.Markup.Declarative.Tests/ControlsTests/BindPropertyStatePopTest.cs
+++ b/src/Avalonia.Markup.Declarative.Tests/ControlsTests/BindPropertyStatePopTest.cs
@@ -12,25 +12,35 @@ public class BindPropertyStatePopTest : AvaloniaTestBase
         var view = new SliderTestView();
 
         var window = new Window { Content = view };
-    window.Show();
+        window.Show();
 
-    Assert.Equal(1, view.Value);
+        Assert.Equal(1, view.Value);
 
         var expectedValue = 50;
         view._wrapper._slider.Value = expectedValue;
-        
-    Assert.Equal(expectedValue, view._wrapper.Value);
+
+        Assert.Equal(expectedValue, view._wrapper.Value);
         view._wrapper.UpdateState();
-    view.UpdateState();
-    Assert.Equal(expectedValue, view.Value);
+        view.UpdateState();
+        Assert.Equal(expectedValue, view.Value);
     }
 
     public class SliderWrapper : ComponentBase
     {
         protected override object Build() =>
-            new Slider()
-                .Ref(out _slider)
-                .Value(() => Value, v => Value = v);
+            new StackPanel().Children(
+                new NumericUpDown()
+                    .Col(1)
+                    .Width(80)
+                    .Minimum(() => 0)
+                    .Maximum(() => 100)
+                    .Increment(1)
+                    .Value(() => (decimal?)Value, v => Value = (double)v!),
+
+                new Slider()
+                    .Ref(out _slider)
+                    .Value(() => Value, v => Value = v)
+            );
 
         public Slider _slider = null!;
         public double Value { get; set; }

--- a/src/Avalonia.Markup.Declarative.Tests/ControlsTests/ModalHostTests.cs
+++ b/src/Avalonia.Markup.Declarative.Tests/ControlsTests/ModalHostTests.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using Avalonia.Controls;
-using Xunit;
 
 namespace Avalonia.Markup.Declarative.Tests.ControlsTests;
 
@@ -73,6 +71,6 @@ public class ModalHostTests : AvaloniaTestBase
 
         // Build executed with MainContent == null, so only the modals panel is present
         Assert.NotNull(host.HostPanel);
-        Assert.Equal(1, host.HostPanel!.Children.Count);
+        Assert.Single(host.HostPanel!.Children);
     }
 }

--- a/src/Samples/AvaloniaMarkupSample/MvuSample/SampleMvuView.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvuSample/SampleMvuView.cs
@@ -70,12 +70,18 @@ public class SampleMvuView : ComponentBase
                         new TextBlock()
                             .Text(() => $"Counter: {(Counter == 0 ? "zero" : Counter)}"),
                         new NumericUpDown()
-                            .Value(() => Counter, v => Counter = v)
+                            .Value(() => Counter, v => Counter = v),
 
+                        new SliderEx()
+                            .Label("Slider sample")
+                            .Units("px")
+                            .Minimum(1)
+                            .Value(() => SliderValue, v => SliderValue = (float)v)
                     )
             );
 
     private decimal? Counter { get; set; } = 0;
+    private float SliderValue { get; set; } = 10;
 
     private string _myNotifiedProperty1 = "Click me";
 

--- a/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
@@ -1,0 +1,52 @@
+﻿using System.Globalization;
+
+namespace AvaloniaMarkupSample.MvuSample;
+
+public class SliderEx : ComponentBase
+{
+    protected override object Build() =>
+        new Grid()
+            .Rows("Auto,Auto")
+            .Cols("Auto,*, 20")
+            .Margin(0, 4)
+            .Children(
+                new TextBlock()
+                    .Text(() => Label)
+                    .VerticalAlignment(VerticalAlignment.Center),
+
+                new NumericUpDown()
+                    .Col(1)
+                    .HorizontalAlignment(HorizontalAlignment.Right)
+                    .Width(80)
+                    .Minimum(() => (decimal)Minimum)
+                    .Maximum(() => (decimal)Maximum)
+                    .NumberFormat(new NumberFormatInfo() { NumberDecimalDigits = 0 })
+                    .Increment(1)
+                    .Value(() => (decimal?)Value, v => Value = (double)v!),
+
+                new TextBlock()
+                    .Text(() => Units)
+                    .VerticalAlignment(VerticalAlignment.Center)
+                    .Margin(4)
+                    .Col(2),
+
+                new Slider()
+                    .Row(1)
+                    .ColSpan(3)
+                    .TickFrequency(1)
+                    .IsSnapToTickEnabled(true)
+                    .Maximum(() => Maximum)
+                    .Minimum(() => Minimum)
+                    .SmallChange(1)
+                    .LargeChange(10)
+                    .Value(() => Value, v => Value = v)
+            );
+
+    public double Value { get; set; } = 0;
+    public double Minimum { get; set; } = 0;
+    public double Maximum { get; set; } = 100;
+    public string Label { get; set; } = "";
+    public string Units { get; set; } = "";
+
+
+}

--- a/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
@@ -47,6 +47,4 @@ public class SliderEx : ComponentBase
     public double Maximum { get; set; } = 100;
     public string Label { get; set; } = "";
     public string Units { get; set; } = "";
-
-
 }

--- a/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
@@ -7,7 +7,7 @@ public class SliderEx : ComponentBase
     protected override object Build() =>
         new Grid()
             .Rows("Auto,Auto")
-            .Cols("Auto,Auto,* 20")
+            .Cols("Auto,*, 60, 20")
             .Margin(0, 4)
             .Children(
                 new TextBlock()
@@ -23,11 +23,12 @@ public class SliderEx : ComponentBase
                 new NumericUpDown()
                     .Col(2)
                     .HorizontalAlignment(HorizontalAlignment.Right)
+                    .MinWidth(150)
                     .Minimum(() => (decimal)Minimum)
                     .Maximum(() => (decimal)Maximum)
                     .NumberFormat(new NumberFormatInfo() { NumberDecimalDigits = 0 })
                     .Increment(1)
-                    .Value(() => (decimal?)Value, v => Value = (double)(v ?? 0)),
+                    .Value(() => (decimal?)Value, v => { if (v.HasValue) Value = (double)v.Value; }),
 
                 new TextBlock()
                     .Text(() => Units)

--- a/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
+++ b/src/Samples/AvaloniaMarkupSample/MvuSample/SliderEx.cs
@@ -7,32 +7,37 @@ public class SliderEx : ComponentBase
     protected override object Build() =>
         new Grid()
             .Rows("Auto,Auto")
-            .Cols("Auto,*, 20")
+            .Cols("Auto,Auto,* 20")
             .Margin(0, 4)
             .Children(
                 new TextBlock()
                     .Text(() => Label)
                     .VerticalAlignment(VerticalAlignment.Center),
 
+                new TextBlock()
+                    .Text(() => $"Value: {Value}")
+                    .VerticalAlignment(VerticalAlignment.Center)
+                    .Margin(4)
+                    .Col(1),
+
                 new NumericUpDown()
-                    .Col(1)
+                    .Col(2)
                     .HorizontalAlignment(HorizontalAlignment.Right)
-                    .Width(80)
                     .Minimum(() => (decimal)Minimum)
                     .Maximum(() => (decimal)Maximum)
                     .NumberFormat(new NumberFormatInfo() { NumberDecimalDigits = 0 })
                     .Increment(1)
-                    .Value(() => (decimal?)Value, v => Value = (double)v!),
+                    .Value(() => (decimal?)Value, v => Value = (double)(v ?? 0)),
 
                 new TextBlock()
                     .Text(() => Units)
                     .VerticalAlignment(VerticalAlignment.Center)
                     .Margin(4)
-                    .Col(2),
+                    .Col(3),
 
                 new Slider()
                     .Row(1)
-                    .ColSpan(3)
+                    .ColSpan(4)
                     .TickFrequency(1)
                     .IsSnapToTickEnabled(true)
                     .Maximum(() => Maximum)


### PR DESCRIPTION
This pull request introduces significant improvements to property binding and propagation in the Avalonia Markup Declarative framework, along with enhancements to the source generator and new sample/test components for property synchronization. The most important changes focus on making property updates more robust and ensuring that changes propagate correctly between nested components, as well as improving the handling of generic and nested types in the source generator.

**Property Binding and Propagation Improvements:**

* Enhanced `ViewPropertyComputedState` to track and propagate property changes more reliably, including immediate observer notification, prevention of recursive updates, and bubbling property changes up to parent components using the current view context. This ensures two-way synchronization between nested components and their parents. [[1]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R34-R38) [[2]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R65-R70) [[3]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R85-R93) [[4]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R118-R133) [[5]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R143-R201) [[6]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R225-R229)

**Source Generator Enhancements:**

* Refactored extension class name generation in `AvaloniaPropertyExtensionsGenerator.cs` to handle nested and generic types properly, ensuring generated file names and class names are unique and valid. Also improved detection of types implementing `IDeclarativeViewBase` via inheritance. [[1]](diffhunk://#diff-01b21423f70952d5b9c22e1c70516652f7a81f2e7794af6f3206ff269f8d8568R43-R68) [[2]](diffhunk://#diff-01b21423f70952d5b9c22e1c70516652f7a81f2e7794af6f3206ff269f8d8568L76-R113) [[3]](diffhunk://#diff-01b21423f70952d5b9c22e1c70516652f7a81f2e7794af6f3206ff269f8d8568L148-R183)
* Simplified LINQ usage in `MarkupTypeHelpers.cs` for finding markup views.

**New and Improved Tests and Samples:**

* Added `BindPropertySameLevelSyncTest` to verify that property changes in nested controls are correctly propagated to parent components, and updated `BindPropertyStatePopTest` to include a numeric up-down control for more comprehensive testing. [[1]](diffhunk://#diff-57514db67132d2d8513934155957074e42018f93a48144caecfb046dd8ce6affR1-R85) [[2]](diffhunk://#diff-0c0129e2a255c897731971bf49a0e37bd1868291e39599f29786cc879cb712a6R29-R41)
* Introduced a new `SliderEx` sample component and integrated it into the MVU sample view to demonstrate advanced property binding and UI synchronization. [[1]](diffhunk://#diff-e8ee6c5bb7d549afe231e34e56e47b536b406b6e26caccee9076430bc247192bR1-R55) [[2]](diffhunk://#diff-6ff7ffc088945ba2b867b3287282afa9f78c210b3afbcc52c5a09f8aeddd5c43L73-R84)

**Minor Test and Code Quality Updates:**

* Cleaned up unused usings and improved assertion style in `ModalHostTests.cs`. [[1]](diffhunk://#diff-b4e0b3aeb2a810309d1e9956fb766dc0fd75c06e837d8b90388503a390d53bd4L1-L3) [[2]](diffhunk://#diff-b4e0b3aeb2a810309d1e9956fb766dc0fd75c06e837d8b90388503a390d53bd4L76-R74)

---

**References:**  
Property Binding and Propagation: [[1]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R34-R38) [[2]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R65-R70) [[3]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R85-R93) [[4]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R118-R133) [[5]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R143-R201) [[6]](diffhunk://#diff-844d7997fd454f461f396e5171299b9309a45c4d7672778f6922fb8539f472e3R225-R229)  
Source Generator: [[1]](diffhunk://#diff-01b21423f70952d5b9c22e1c70516652f7a81f2e7794af6f3206ff269f8d8568R43-R68) [[2]](diffhunk://#diff-01b21423f70952d5b9c22e1c70516652f7a81f2e7794af6f3206ff269f8d8568L76-R113) [[3]](diffhunk://#diff-01b21423f70952d5b9c22e1c70516652f7a81f2e7794af6f3206ff269f8d8568L148-R183) [[4]](diffhunk://#diff-e9326acc313b0629ef452432e8fd60dfa38fac0d0ea210e389217071013cf835L29-R29)  
Tests and Samples: [[1]](diffhunk://#diff-57514db67132d2d8513934155957074e42018f93a48144caecfb046dd8ce6affR1-R85) [[2]](diffhunk://#diff-0c0129e2a255c897731971bf49a0e37bd1868291e39599f29786cc879cb712a6R29-R41) [[3]](diffhunk://#diff-e8ee6c5bb7d549afe231e34e56e47b536b406b6e26caccee9076430bc247192bR1-R55) [[4]](diffhunk://#diff-6ff7ffc088945ba2b867b3287282afa9f78c210b3afbcc52c5a09f8aeddd5c43L73-R84)  
Code Quality: [[1]](diffhunk://#diff-b4e0b3aeb2a810309d1e9956fb766dc0fd75c06e837d8b90388503a390d53bd4L1-L3) [[2]](diffhunk://#diff-b4e0b3aeb2a810309d1e9956fb766dc0fd75c06e837d8b90388503a390d53bd4L76-R74)