### PR TITLE
fix: Support AddHandler detection for routed event extensions

### DIFF
--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExtensionInfos/EventExtensionInfo.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExtensionInfos/EventExtensionInfo.cs
@@ -17,6 +17,7 @@ internal sealed class EventExtensionInfo : IMemberExtensionInfo
     public string GenericConstraint { get; } = "";
     public string GenericArg { get; } = "";
     public bool IsRoutedEvent { get; }
+    public bool SupportsAddHandler { get; }
     public bool IsObsolete { get; }
 
     public bool HasStandardSignature =>
@@ -33,6 +34,7 @@ internal sealed class EventExtensionInfo : IMemberExtensionInfo
         XmlDoc = SymbolUtilities.FormatXmlDoc(eventInfo);
         IsObsolete = eventInfo.IsObsolete();
         IsRoutedEvent = IsRoutedEventSymbol(eventInfo);
+        SupportsAddHandler = eventInfo.ContainingType.IsOrInheritsFrom("Avalonia.Interactivity.Interactive");
 
         if (!eventInfo.ContainingType.IsSealed)
         {

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/EventGenerators/ActionToEventGenerator.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/EventGenerators/ActionToEventGenerator.cs
@@ -52,7 +52,7 @@ internal sealed class ActionToEventGenerator : ExtensionGeneratorBase<EventExten
         }
 
         // 2. RoutedEvents (Avalonia routing events)
-        if (@event.IsRoutedEvent)
+        if (@event.IsRoutedEvent && @event.SupportsAddHandler)
         {
             return $"{documentation}{obsolete}public static {@event.ReturnType} On{@event.EventName}{@event.GenericArg}(this {@event.ReturnType} control, {argsString}, Avalonia.Interactivity.RoutingStrategies? routes = null) {@event.GenericConstraint}\n" +
                    $"{{\n" +

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/ExternalAssemblyExtensionsGenerator.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/ExternalAssemblyExtensionsGenerator.cs
@@ -153,6 +153,7 @@ public sealed class ExternalAssemblyExtensionsGenerator : IIncrementalGenerator
         AppendSignaturePart(signature, info.GenericConstraint);
         AppendSignaturePart(signature, info.GenericArg);
         AppendSignaturePart(signature, info.IsRoutedEvent ? "routed" : "plain");
+        AppendSignaturePart(signature, info.SupportsAddHandler ? "addhandler" : "subscription");
         AppendSignaturePart(signature, info.IsObsolete ? "obsolete" : "active");
         AppendSignaturePart(signature, info.ReturnsVoid ? "void" : "nonvoid");
 

--- a/src/Avalonia.Markup.Declarative.Tests/ControlsTests/NonInteractiveRoutedEventExtensionTests.cs
+++ b/src/Avalonia.Markup.Declarative.Tests/ControlsTests/NonInteractiveRoutedEventExtensionTests.cs
@@ -1,0 +1,24 @@
+using Avalonia;
+using Avalonia.Interactivity;
+
+namespace Avalonia.Markup.Declarative.Tests.ControlsTests;
+
+public class NonInteractiveRoutedEventExtensionTests
+{
+    [Fact]
+    public void Routed_event_on_non_interactive_avalonia_object_compiles()
+    {
+        var control = new NonInteractiveRoutedEventControl();
+        control.OnColumnChanged(x => { });
+    }
+}
+
+public class NonInteractiveRoutedEventControl : AvaloniaObject
+{
+    public static readonly RoutedEvent<RoutedEventArgs> ColumnChangedEvent =
+        new(nameof(ColumnChanged), RoutingStrategies.Bubble, typeof(NonInteractiveRoutedEventControl));
+
+    public event EventHandler<RoutedEventArgs>? ColumnChanged;
+
+    public void RaiseColumnChanged() => ColumnChanged?.Invoke(this, new RoutedEventArgs());
+}


### PR DESCRIPTION
Add SupportsAddHandler to EventExtensionInfo to distinguish routed events on interactive vs non-interactive types. Update extension generation logic to only use AddHandler for eligible types, adjust signature hashing, and add tests for non-interactive routed events.

Fixes: #123 