### PR TITLE
Bump Avalonia to 12.0.5 and align package version and Added BindingBase overload generator

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
 	<PropertyGroup>
-		<Version>12.0.5-preview1</Version>
+		<Version>12.0.5</Version>
 	</PropertyGroup>
 </Project>

--- a/Templates/Declarative.Avalonia.Templates/content/Avalonia.Declarative.Template.1/Avalonia.Declarative.Template.1.csproj
+++ b/Templates/Declarative.Avalonia.Templates/content/Avalonia.Declarative.Template.1/Avalonia.Declarative.Template.1.csproj
@@ -18,9 +18,9 @@
 		<TrimmableAssembly Include="Avalonia.Themes.Default" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
-		<PackageReference Include="Avalonia.Markup.Declarative" Version="12.0.4" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+		<PackageReference Include="Avalonia.Markup.Declarative" Version="12.0.5" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,27 @@ If you assign `DataContext` from the outside, the same generated setters also su
 
 Generated compiled-binding setters also apply automatic conversion for common primitive and nullable mismatches, so bindings like `new Slider().Value(vm, x => x.Counter, BindingMode.TwoWay)` work when `Counter` is `int`, and `new CheckBox().IsChecked(vm, x => x.Enabled)` work when `Enabled` is `bool`. Prefer plain member access such as `x => x.Counter`: a numeric-conversion cast like `x => (double)x.Counter` is both unnecessary (the auto-converter handles it) and unsupported — Avalonia's expression parser rejects value-converting `Convert` nodes. Type casts that navigate to a member of a derived type, such as `x => ((DerivedType)x).Property`, *are* supported. For lossy numeric `TwoWay` conversions, convert-back truncates toward zero.
 
+### Passing a ready-made binding
+
+When you need the full binding feature set — reflection bindings (`Binding`), a pre-built compiled binding, a `TemplateBinding`, a `MultiBinding`, or a relative-source/element-name binding — every generated property, attached-property and style setter also exposes an overload that accepts a `BindingBase` directly:
+
+```csharp
+using Avalonia.Data;
+
+new TextBlock()
+    .Text(new Binding("ReflectionProperty"))                                // DataContext-relative reflection binding
+    .Foreground(new Binding("Theme.Accent") { Source = appState });         // explicit source
+
+new TextBlock()
+    .Text(CompiledBinding.Create<MyViewModel, string>(x => x.Title, source: vm));
+
+// attached properties and styles get the same overload
+new Border().Grid_Row(new Binding(nameof(vm.Row)) { Source = vm });
+new Style<TextBlock>().Text(new Binding(nameof(vm.Name)));
+```
+
+This is the escape hatch for anything the strongly-typed `x => x.Member` expression overloads don't cover (custom converters passed on the binding, `RelativeSource`, `ElementName`, string format, multi-value bindings, etc.). The same thing is available on any `AvaloniaProperty` via `control.BindValue(TextBlock.TextProperty, binding)`.
+
 ## Hot reload support
 
 - `ViewBase` supports .NET 6.0+ hot reload.

--- a/src/Avalonia.Markup.Declarative.Diagnostics.Tests/Avalonia.Markup.Declarative.Diagnostics.Tests.csproj
+++ b/src/Avalonia.Markup.Declarative.Diagnostics.Tests/Avalonia.Markup.Declarative.Diagnostics.Tests.csproj
@@ -11,10 +11,10 @@
 
   <ItemGroup>
     <!-- Real (Skia) headless rendering so RenderTargetBitmap produces valid PNGs. -->
-    <PackageReference Include="Avalonia.Headless" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Skia" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Headless" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Skia" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/Avalonia.Markup.Declarative.SourceGenerator.csproj
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/Avalonia.Markup.Declarative.SourceGenerator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
@@ -13,7 +13,7 @@
 		<AvaloniaNameGeneratorIsEnabled>false</AvaloniaNameGeneratorIsEnabled>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Avalonia" Version="12.0.4" ExcludeAssets="analyzers" />
+		<PackageReference Include="Avalonia" Version="12.0.5" ExcludeAssets="analyzers" />
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
 		<PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
 	</ItemGroup>

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/AttachedPropertySetterGenerator/AttachedPropertyBindFromBindingSetterGenerator.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/AttachedPropertySetterGenerator/AttachedPropertyBindFromBindingSetterGenerator.cs
@@ -1,0 +1,27 @@
+using Avalonia.Markup.Declarative.SourceGenerator.ExtensionInfos;
+
+namespace Avalonia.Markup.Declarative.SourceGenerator.ExternalGenerators.AttachedPropertySetterGenerator;
+
+/// <summary>
+/// Generates a named overload for each attached property that accepts a ready-made <c>BindingBase</c>, e.g.
+/// <c>new TextBlock().Grid_Row(new Binding("Row"))</c>. See issue #121.
+/// </summary>
+internal sealed class AttachedPropertyBindFromBindingSetterGenerator : ExtensionGeneratorBase<AttachedPropertyExtensionInfo>
+{
+    protected override string? GetExtension(AttachedPropertyExtensionInfo info)
+    {
+        if (string.IsNullOrWhiteSpace(info.AttachedPropertyHostTypeName))
+        {
+            return null;
+        }
+
+        if (info.ValueTypeSource is "global::Avalonia.Data.BindingBase" or "global::Avalonia.Data.BindingBase?")
+        {
+            return null;
+        }
+
+        return PrefixDocumentation(info.XmlDoc,
+            $"public static T {info.ExtensionName}<T>(this T control, BindingBase binding{CallerInfoParameters}) where T : {info.AttachedPropertyHostTypeName} {SymbolUtilities.NewLine}" +
+            $"   => control.BindValue({info.ControlTypeName}.{info.FieldSymbol.Name}!, binding{CallerInfoArguments});");
+    }
+}

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/ExternalGeneratorHost.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/ExternalGeneratorHost.cs
@@ -18,6 +18,7 @@ internal sealed class ExternalGeneratorHost
 
             new ValueSetterGenerator(),
             new BindFromExpressionSetterGenerator(),
+            new BindFromBindingSetterGenerator(),
             new ValueOverloadsSetterGenerator()
         ),
 
@@ -25,7 +26,8 @@ internal sealed class ExternalGeneratorHost
             static t => GetAttachedPropertyInfos(t),
 
             new AttachedPropertyValueSetterGenerator(),
-            new AttachedPropertyBindFromExpressionSetterGenerator()
+            new AttachedPropertyBindFromExpressionSetterGenerator(),
+            new AttachedPropertyBindFromBindingSetterGenerator()
         ),
 
         new("Events",
@@ -39,6 +41,7 @@ internal sealed class ExternalGeneratorHost
 
             new ValueStyleSetterGenerator(),
             new BindFromExpressionStyleSetterGenerator(),
+            new BindFromBindingStyleSetterGenerator(),
             new ValueOverloadsStyleSetterGenerator()
         )
     ];

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/SetterGenerators/BindFromBindingSetterGenerator.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/SetterGenerators/BindFromBindingSetterGenerator.cs
@@ -1,0 +1,25 @@
+using Avalonia.Markup.Declarative.SourceGenerator.ExtensionInfos;
+
+namespace Avalonia.Markup.Declarative.SourceGenerator.ExternalGenerators.SetterGenerators;
+
+/// <summary>
+/// Generates a named overload for each property that accepts a ready-made <c>BindingBase</c>
+/// (reflection <c>Binding</c>, compiled binding, template binding, multi-binding, …), e.g.
+/// <c>new TextBlock().Text(new Binding("Value"))</c>. See issue #121.
+/// </summary>
+internal sealed class BindFromBindingSetterGenerator : ExtensionGeneratorBase<PropertyExtensionInfo>
+{
+    protected override string? GetExtension(PropertyExtensionInfo info)
+    {
+        // Guard against the (rare) property whose own value type is BindingBase, so the generated
+        // overload never collides with the value setter of the same signature.
+        if (info.ValueTypeSource is "global::Avalonia.Data.BindingBase" or "global::Avalonia.Data.BindingBase?")
+        {
+            return null;
+        }
+
+        return PrefixDocumentation(info.XmlDoc,
+            $"public static {info.ReturnType} {info.ExtensionName}{info.GenericArg}(this {info.ReturnType} control, BindingBase binding{CallerInfoParameters}) {info.GenericConstraint} {SymbolUtilities.NewLine}" +
+            $"   => control.BindValue({info.ControlTypeName}.{info.FieldSymbol.Name}!, binding{CallerInfoArguments});");
+    }
+}

--- a/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/StyleSetterGenerators/BindFromBindingStyleSetterGenerator.cs
+++ b/src/Avalonia.Markup.Declarative.SourceGenerator/ExternalGenerators/StyleSetterGenerators/BindFromBindingStyleSetterGenerator.cs
@@ -1,0 +1,23 @@
+using Avalonia.Markup.Declarative.SourceGenerator.ExtensionInfos;
+
+namespace Avalonia.Markup.Declarative.SourceGenerator.ExternalGenerators.StyleSetterGenerators;
+
+/// <summary>
+/// Generates a named style-setter overload for each property that accepts a ready-made <c>BindingBase</c>, e.g.
+/// <c>new Style&lt;TextBlock&gt;().Text(new Binding("Value"))</c>. Avalonia treats a <c>BindingBase</c> assigned to a
+/// <c>Setter.Value</c> as a binding, so this routes through the existing <c>_addSetter</c> value setter. See issue #121.
+/// </summary>
+internal sealed class BindFromBindingStyleSetterGenerator : ExtensionGeneratorBase<PropertyExtensionInfo>
+{
+    protected override string? GetExtension(PropertyExtensionInfo info)
+    {
+        if (info.ValueTypeSource is "global::Avalonia.Data.BindingBase" or "global::Avalonia.Data.BindingBase?")
+        {
+            return null;
+        }
+
+        return PrefixDocumentation(info.XmlDoc,
+            $"public static Style<{info.ReturnType}> {info.ExtensionName}{info.GenericArg}(this Style<{info.ReturnType}> style, BindingBase binding{CallerInfoParameters}) {info.StyleGenericConstraint} {SymbolUtilities.NewLine}" +
+            $"   => style._addSetter({info.ControlTypeName}.{info.MemberName}Property!, binding, _callerFile, _callerLine);");
+    }
+}

--- a/src/Avalonia.Markup.Declarative.Tests/Avalonia.Markup.Declarative.Tests.csproj
+++ b/src/Avalonia.Markup.Declarative.Tests/Avalonia.Markup.Declarative.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -15,9 +15,9 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Headless" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.4" />
-    <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Headless" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Headless.XUnit" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.5" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Avalonia.Markup.Declarative.Tests/BindingTests/BindingBaseOverloadTests.cs
+++ b/src/Avalonia.Markup.Declarative.Tests/BindingTests/BindingBaseOverloadTests.cs
@@ -1,0 +1,168 @@
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Styling;
+using Avalonia.Threading;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using FluentAssertions;
+
+namespace Avalonia.Markup.Declarative.Tests.BindingTests;
+
+// Regression coverage for issue #121: the source generator emits a named overload for every
+// property/attached-property/style setter that accepts a ready-made BindingBase, so a reflection
+// Binding or a compiled binding can be passed directly:
+//     new TextBlock().Text(new Binding("Name"))
+//     new TextBlock().Text(CompiledBinding.Create<Vm, string>(x => x.Name, source: vm))
+public class BindingBaseOverloadTests : AvaloniaTestBase
+{
+    public class Vm : INotifyPropertyChanged
+    {
+        private string _name = "initial";
+        public string Name { get => _name; set { _name = value; OnPropertyChanged(); } }
+
+        private int _row;
+        public int Row { get => _row; set { _row = value; OnPropertyChanged(); } }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged([CallerMemberName] string? n = null)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(n));
+    }
+
+    // ---- reflection Binding resolved via the inherited DataContext ----
+    public class ReflectionBindingView : ViewBase<Vm>
+    {
+        public ReflectionBindingView(Vm vm) : base(vm) { }
+        protected override object Build(Vm? vm) =>
+            new TextBlock()
+                .Ref(out Tb)
+                .Text(new Binding(nameof(Vm.Name)));
+        public TextBlock Tb = null!;
+    }
+
+    [Fact]
+    public void ReflectionBinding_Overload_BindsAndStaysReactive()
+    {
+        var vm = new Vm();
+        var view = new ReflectionBindingView(vm);
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        view.Tb.Text.Should().Be("initial");
+
+        vm.Name = "updated";
+        Dispatcher.UIThread.RunJobs();
+
+        view.Tb.Text.Should().Be("updated");
+    }
+
+    // ---- compiled binding created explicitly ----
+    public class CompiledBindingView : ViewBase<Vm>
+    {
+        public CompiledBindingView(Vm vm) : base(vm) { }
+        protected override object Build(Vm? vm) =>
+            new TextBlock()
+                .Ref(out Tb)
+                .Text(CompiledBinding.Create<Vm, string>(x => x.Name, source: vm!));
+        public TextBlock Tb = null!;
+    }
+
+    [Fact]
+    public void CompiledBinding_Overload_BindsAndStaysReactive()
+    {
+        var vm = new Vm();
+        var view = new CompiledBindingView(vm);
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        view.Tb.Text.Should().Be("initial");
+
+        vm.Name = "changed";
+        Dispatcher.UIThread.RunJobs();
+
+        view.Tb.Text.Should().Be("changed");
+    }
+
+    // ---- reflection Binding with an explicit Source (no DataContext plumbing) ----
+    [Fact]
+    public void ReflectionBinding_WithExplicitSource_Binds()
+    {
+        var vm = new Vm { Name = "srcval" };
+        var tb = new TextBlock()
+            .Text(new Binding(nameof(Vm.Name)) { Source = vm });
+
+        var window = new Window { Content = tb };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        tb.Text.Should().Be("srcval");
+    }
+
+    // ---- TwoWay reflection binding round-trips ----
+    [Fact]
+    public void ReflectionBinding_TwoWay_UpdatesSource()
+    {
+        var vm = new Vm { Name = "start" };
+        var box = new TextBox()
+            .Text(new Binding(nameof(Vm.Name)) { Source = vm, Mode = BindingMode.TwoWay });
+
+        var window = new Window { Content = box };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        box.Text.Should().Be("start");
+
+        box.Text = "typed";
+        Dispatcher.UIThread.RunJobs();
+
+        vm.Name.Should().Be("typed");
+    }
+
+    // ---- style setter binding overload (DataContext-relative reflection binding) ----
+    public class StyledView : ViewBase<Vm>
+    {
+        public StyledView(Vm vm) : base(vm) { }
+
+        // BuildStyles() runs from the base constructor before any derived field is set, so the
+        // binding must be DataContext-relative: the root TextBlock inherits the view's DataContext.
+        protected override StyleGroup? BuildStyles() =>
+        [
+            new Style<TextBlock>()
+                .Text(new Binding(nameof(Vm.Name)))
+        ];
+
+        protected override object Build(Vm? vm) =>
+            new TextBlock().Ref(out Tb);
+
+        public TextBlock Tb = null!;
+    }
+
+    [Fact]
+    public void StyleSetter_BindingOverload_Applies()
+    {
+        var vm = new Vm { Name = "styled" };
+        var view = new StyledView(vm);
+        var window = new Window { Content = view };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        view.Tb.Text.Should().Be("styled");
+    }
+
+    // ---- attached-property binding overload ----
+    [Fact]
+    public void AttachedProperty_BindingOverload_Applies()
+    {
+        var vm = new Vm { Row = 3 };
+        var child = new Border()
+            .Grid_Row(new Binding(nameof(Vm.Row)) { Source = vm });
+
+        var grid = new Grid().Children(child);
+        var window = new Window { Content = grid };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Grid.GetRow(child).Should().Be(3);
+    }
+}

--- a/src/Avalonia.Markup.Declarative/Avalonia.Markup.Declarative.csproj
+++ b/src/Avalonia.Markup.Declarative/Avalonia.Markup.Declarative.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
@@ -38,7 +38,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="System.Collections.Immutable" Version="10.0.9" />
-		<PackageReference Include="Avalonia" Version="12.0.4" />
+		<PackageReference Include="Avalonia" Version="12.0.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Avalonia.Markup.Declarative/ControlPropertyExtensions.cs
+++ b/src/Avalonia.Markup.Declarative/ControlPropertyExtensions.cs
@@ -126,8 +126,9 @@ public static class ControlPropertyExtensions
     /// </summary>
     /// <remarks>
     /// Unlike the strongly-typed expression overloads (e.g. <c>Text(source, x =&gt; x.Value)</c>), this method accepts a
-    /// ready-made <see cref="BindingBase"/>, so it works with the full feature set of reflection bindings (<see cref="Binding"/>)
-    /// and compiled bindings.
+    /// ready-made <see cref="BindingBase"/>, so it works with the full feature set of reflection bindings (<see cref="Binding"/>),
+    /// compiled bindings (<c>CompiledBinding</c>), template bindings and multi-bindings.
+    /// The generated per-property setters expose this as a named overload, e.g. <c>new TextBlock().Text(new Binding("Value"))</c>.
     /// </remarks>
     /// <typeparam name="TControl">The control type, which must derive from <see cref="AvaloniaObject"/>.</typeparam>
     /// <param name="control">The control to bind. Cannot be null.</param>

--- a/src/Samples/AvaloniaMarkupSample/AvaloniaMarkupSample.csproj
+++ b/src/Samples/AvaloniaMarkupSample/AvaloniaMarkupSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>

--- a/src/Samples/DeclarativeComponentTemplate/DeclarativeComponentTemplate.csproj
+++ b/src/Samples/DeclarativeComponentTemplate/DeclarativeComponentTemplate.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net10.0</TargetFramework>
@@ -22,10 +22,10 @@
 		<TrimmableAssembly Include="Avalonia.Themes.Default" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
 		<!--Condition below is needed to remove diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Tmds.DBus.Protocol" Version="0.92.0" />

--- a/src/Samples/ReactiveSample/ReactiveSample.csproj
+++ b/src/Samples/ReactiveSample/ReactiveSample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
     <PackageReference Include="ReactiveUI" Version="23.2.28" />
     <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageReference Include="ReactiveUI.SourceGenerators" Version="3.1.0">


### PR DESCRIPTION
## Summary
- Update all Avalonia packages `12.0.4` → `12.0.5` (latest release) across the library, source generator, tests, templates and samples
- Update `AvaloniaUI.DiagnosticsSupport` `2.2.2` → `2.2.3` (latest release)
- Bump our package `Version` `12.0.5-preview1` → `12.0.5` to match the Avalonia release

## Notes
- `ReactiveUI.Avalonia` left at `12.0.3` — it is the latest stable in the 12.0.x line (next is `12.1.0-beta.1` / a jump to `14.7.1`), there is no `12.0.4/12.0.5` for it.

## Testing
- `dotnet build -c Release` → succeeded, 0 warnings / 0 errors
- `dotnet test -c Release` → **45 passed, 0 failed** (38 + 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)